### PR TITLE
Firefox fixes

### DIFF
--- a/log-skeleton/src/components/activities.js
+++ b/log-skeleton/src/components/activities.js
@@ -26,7 +26,8 @@ const Activities = () => {
                 {
                     activities.map( activity => {
                         return (
-                            <ActivityBox 
+                            <ActivityBox
+                                key={activity}
                                 title={activity}
                                 callback={handleActivityToggle}
                                 toggle={model.activeActivities.includes(activity)}/>

--- a/log-skeleton/src/components/activity-filter.js
+++ b/log-skeleton/src/components/activity-filter.js
@@ -64,7 +64,8 @@ const ActivityFilter = (props) =>{
             <div className={styles.contentContainer}>
                 {props.source.map(item=>{
                     return(
-                        <ListItem 
+                        <ListItem
+                            key={item}
                             title={item}
                             callback={props.callback}
                             colorClass={props.colorClass}

--- a/log-skeleton/src/components/content.js
+++ b/log-skeleton/src/components/content.js
@@ -25,7 +25,6 @@ const Content = () => {
             <div className={styles.sidePanel}>
                 <RequiredActivities></RequiredActivities>
                 <ForbiddenActivities></ForbiddenActivities>
-                {/* <Splitter value={[[1,2],[3,4]]}/> */}
             </div>
 
             <div className={styles.midPanel}>

--- a/log-skeleton/src/components/graph-visualisation.js
+++ b/log-skeleton/src/components/graph-visualisation.js
@@ -33,8 +33,6 @@ const GraphVisualizer = () => {
                                    model.config.parameters['trace-start'],
                                    model.config.parameters['trace-end'])
         
-        console.log(graph);
-
         updateGraph(graph)
 
       }, [model.filteredLogSkeleton, model.config.parameters])

--- a/log-skeleton/src/components/navigation.js
+++ b/log-skeleton/src/components/navigation.js
@@ -37,7 +37,6 @@ const NavigationBar = () => {
 
 
     useEffect(() => {
-        console.log('effect ' + showMenu)
         if (showMenu) {
             document.addEventListener('click', closeMenu)
         } else {
@@ -58,10 +57,6 @@ const NavigationBar = () => {
             </div>
             <ul className={styles.navContainer}>
                 <LogSkeletonStatus></LogSkeletonStatus>
-                {/* <NavItem
-                    icon={<BellIcon className={styles.icon} />}>
-
-                </NavItem> */}
                 <NavItem
                     icon={<LogSkeletonIcon className={styles.icon} />}>
                     <DropDown>

--- a/log-skeleton/src/components/noise-threshold.js
+++ b/log-skeleton/src/components/noise-threshold.js
@@ -1,46 +1,30 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useLogSkeleton } from '../lib/api/log-skeleton'
 import styles from "../styles/SidePanel.module.css";
 import RangeSlider from 'react-bootstrap-range-slider';
 
 const Slider = () =>{
-    const { config, setNoiseThreshold, fetchLogSkeleton } = useLogSkeleton()
-    const noiseThreshold = config.parameters.noiseThreshold
+    const { fetchLogSkeleton } = useLogSkeleton()
 
     //TODO: set initial noise (from the model)
-    // const [ value, setValue ] = React.useState(0.0);
-
-    // const setIfValid = (value) =>{
-    //     if(!isNaN(value) && value>=0 && value <= 1 && value!==""){
-    //         //TODO: set noise threshold here (value)
-    //         setNoiseThreshold(value)
-    //     }
-    //     setValue(value)
-    // }
+    const [ value, setValue ] = useState(0.0);
 
     return (
         <div className={styles.container}>
             <div className={styles.title}>Noise Threshold</div>
             <div className={styles.contentContainer}>
                 <RangeSlider
+                    className={styles.slider}
                     min = {0}
                     max = {1}
                     step = {0.05}
-                    value={noiseThreshold}
-                    tooltipLabel={currentValue => `${(currentValue * 100)}%`}
+                    value={value}
+                    tooltipLabel={currentValue => `${Math.floor((currentValue * 100))}%`}
                     tooltip='on'
-                    onChange={e => setNoiseThreshold(e.target.value)}
-                    onAfterChange={e => fetchLogSkeleton()}
+                    onChange={e => setValue(e.target.value)}
+                    onAfterChange={e => fetchLogSkeleton(value)}
                 >
                 </RangeSlider>
-                {/* <input
-                    type= "number" required
-                    max = {1}
-                    min={0}
-                    step={0.05}
-                    value={noiseThreshold}
-                    onChange={e => setIfValid(e.target.value)} */}
-                {/* /> */}
             </div>
         </div>)
 }

--- a/log-skeleton/src/components/noise-threshold.js
+++ b/log-skeleton/src/components/noise-threshold.js
@@ -1,13 +1,17 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useLogSkeleton } from '../lib/api/log-skeleton'
 import styles from "../styles/SidePanel.module.css";
 import RangeSlider from 'react-bootstrap-range-slider';
 
 const Slider = () =>{
-    const { fetchLogSkeleton } = useLogSkeleton()
+    const { config, fetchLogSkeleton } = useLogSkeleton()
 
     //TODO: set initial noise (from the model)
     const [ value, setValue ] = useState(0.0);
+
+    useEffect(() => {
+        setValue(config.parameters.noiseThreshold)
+    }, [config.parameters.noiseThreshold])
 
     return (
         <div className={styles.container}>

--- a/log-skeleton/src/components/relationships.js
+++ b/log-skeleton/src/components/relationships.js
@@ -33,6 +33,7 @@ const Relationships = () => {
                     relationships.map(relationship => {
                         return (
                             <RelationshipsBox
+                                key={relationship}
                                 title={relationship}
                                 callback={handleRelationshipToggle}
                                 toggle={model.activeRelationships.includes(relationship)}/>

--- a/log-skeleton/src/lib/api/log-skeleton.js
+++ b/log-skeleton/src/lib/api/log-skeleton.js
@@ -238,7 +238,7 @@ const useProvideLogSkeleton = () => {
         }
 
         if (noiseThreshold === null) {
-            noiseThreshold = config.parameters.noiseThreshold
+            noiseThreshold = 0.0
         }
 
         console.log('Fetching log skeleton')
@@ -381,6 +381,7 @@ const useProvideLogSkeleton = () => {
     const resetFilteredLogSkeleton = () => {
         setActiveActivities(logSkeleton.activities)
         setActiveRelationships(relationships)
+        setNoiseThreshold(0.0)
         setForbiddenActivities([])
         setRequiredActivities([])
     }

--- a/log-skeleton/src/lib/common/d3-markers.js
+++ b/log-skeleton/src/lib/common/d3-markers.js
@@ -1,40 +1,5 @@
 export const generateMarkers = (svg, radius) => {
 
-    // Arrow at the beginning of the edge
-
-    // Filled color
-    svg.append('defs')
-        .append('marker')
-        .attr('id', 'arrowstart-fill')
-        .attr('viewBox', '-0 -2.5 5 5')
-        .attr('refX', -radius)
-        .attr('refY', 0)
-        .attr('orient', 'auto')
-        .attr('markerWidth', 6)
-        .attr('markerHeight', 6)
-        .attr('xoverflow', 'visible')
-        .append('svg:path')
-        .attr('d', 'M 0,0 L 5 ,-2.5 L 5, 2.5 L 0, 0')
-        .attr('fill', '#000')
-        .style('stroke','none')
-
-    // Outlined
-    svg.append('defs')
-        .append('marker')
-        .attr('id', 'arrowstart-outline')
-        .attr('viewBox', '-0 -2.5 5 5')
-        .attr('refX', -radius)
-        .attr('refY', 0)
-        .attr('orient', 'auto')
-        .attr('markerWidth', 6)
-        .attr('markerHeight', 6)
-        .attr('xoverflow', 'visible')
-        .append('svg:path')
-        .attr('d', 'M 0,0 L 5 ,-2.5 L 5, 2.5 L 0, 0')
-        .attr('fill', '#f4f6f8')
-        .style('stroke','black')
-        .style('stroke-width', '1')
-
     // ----------------------
     // Always after
     // ----------------------
@@ -84,20 +49,17 @@ export const generateMarkers = (svg, radius) => {
     const always_before_start = svg.append('defs')
         .append('marker')
         .attr('id', 'always_before_start')
-        .attr('viewBox', '-0 -2.5 5 10')
-        .attr('refX', -radius + 3.5)
+        .attr('viewBox', '0 -2.5 10 5')
+        .attr('refX', -radius + 6)
         .attr('refY', 0)
         .attr('orient', 'auto')
-        .attr('markerWidth', 20)
-        .attr('markerHeight', 10)
+        .attr('markerWidth', 10)
+        .attr('markerHeight', 5)
         .attr('xoverflow', 'visible')
 
     always_before_start
         .append('svg:path')
-                   // Trianlge on the bottom
-        .attr('d', 'M 3, 0 L 8 ,-2.5 L 8, 2.5 L 3, 0')
-                //    'M 5 -2.5 L 10 -2.5 L 10 2.5 L 5 2.5' + // Outer rect
-                //    'L 5.5 2 L 9.5 2 L 9.5 -2 L 5.5 -2 L 5.5 2 L 5 2.5  M 0,-2.5') // Inner rect
+        .attr('d', 'M 5 0 L 10 -2.5 L 10 2.5 L 5 0')
         .attr('fill', '#000')
         .style('stroke','none')
         .style('stroke-width', 'none')
@@ -111,7 +73,7 @@ export const generateMarkers = (svg, radius) => {
         .attr('fill', 'white')
         .attr('stroke', 'black')
         .attr('stroke-width', '0.75px')
-        .attr('x', '-2.3')
+        // .attr('x', '-2.5')
         .attr('y', '-2.25')
 
     // -------------------
@@ -121,20 +83,17 @@ export const generateMarkers = (svg, radius) => {
     const always_before_combinded = svg.append('defs')
         .append('marker')
         .attr('id', 'always_before_combined')
-        .attr('viewBox', '-0 -2.5 5 10')
+        .attr('viewBox', '0 -2.5 10 5')
         .attr('refX', radius + 3.5)
         .attr('refY', 0)
         .attr('orient', 'auto')
-        .attr('markerWidth', 20)
-        .attr('markerHeight', 10)
+        .attr('markerWidth', 10)
+        .attr('markerHeight', 5)
         .attr('xoverflow', 'visible')
 
     always_before_combinded
         .append('svg:path')
-                   // Trianlge on the bottom
         .attr('d', 'M 0, -2.5 L 5 ,0 L 0, 2.5 L 0, -2.5')
-                //    'M 5 -2.5 L 10 -2.5 L 10 2.5 L 5 2.5' + // Outer rect
-                //    'L 5.5 2 L 9.5 2 L 9.5 -2 L 5.5 -2 L 5.5 2 L 5 2.5  M 0,-2.5') // Inner rect
         .attr('fill', '#000')
         .style('stroke','none')
         .style('stroke-width', 'none')
@@ -150,23 +109,6 @@ export const generateMarkers = (svg, radius) => {
         .attr('stroke-width', '0.75px')
         .attr('x', '5')
         .attr('y', '-2.25')
-
-
-    svg.append('defs')
-        .append('marker')
-        .attr('id', 'arrowend-outline')
-        .attr('viewBox', '-0 -2.5 5 5')
-        .attr('refX', radius - 1.5)
-        .attr('refY', 0)
-        .attr('orient', 'auto')
-        .attr('markerWidth', 6)
-        .attr('markerHeight', 6)
-        .attr('xoverflow', 'visible')
-        .append('svg:path')
-        .attr('d', 'M 0,-2.5 L 5 ,0 L 0, 2.5 L 0, -2.5')
-        .attr('fill', '#f4f6f8')
-        .style('stroke','black')
-        .style('stroke-width', '1')
 
     // Rect for the arrow
 
@@ -206,24 +148,6 @@ export const generateMarkers = (svg, radius) => {
         .style('stroke','black')
         .style('stroke-width', '1')
 
-
-    // Circles
-    svg.append('defs')
-        .append('marker')
-        .attr('id', 'circle-fill')
-        .attr('viewBox', '0 -2.5 5 5')
-        .attr('refX', -radius + 4.5)
-        .attr('refY', 0)
-        .attr('orient', 'auto')
-        .attr('markerWidth', 6)
-        .attr('markerHeight', 6)
-        .attr('xoverflow', 'visible')
-        .append('circle')
-        .attr('r', 5)
-        .attr('fill', 'black')
-        .style('stroke','black')
-        .style('stroke-width', '1')
-
     //-------------------------
     // Next one way
     //-------------------------
@@ -231,11 +155,11 @@ export const generateMarkers = (svg, radius) => {
         .append('marker')
         .attr('id', 'next_one_way_start')
         .attr('viewBox', '-2.5 -2.5 5 5')
-        .attr('refX', -radius + 6.5)
+        .attr('refX', -radius + 4)
         .attr('refY', 0)
         .attr('orient', 'auto')
-        .attr('markerWidth', 6)
-        .attr('markerHeight', 6)
+        .attr('markerWidth', 5)
+        .attr('markerHeight', 5)
         .attr('xoverflow', 'visible')
         .append('circle')
         .attr('r', 2)
@@ -246,18 +170,25 @@ export const generateMarkers = (svg, radius) => {
     svg.append('defs')
         .append('marker')
         .attr('id', 'next_one_way_end')
-        .attr('viewBox', '-0 -2.5 5 5')
-        .attr('refX', radius / 1.5 + 2.5)
+        .attr('viewBox', '0 -2.5 5 5')
+        .attr('refX', radius - 2)
         .attr('refY', 0)
         .attr('orient', 'auto')
-        .attr('markerWidth', 6)
-        .attr('markerHeight', 6)
+        .attr('markerWidth', 5)
+        .attr('markerHeight', 5)
         .attr('xoverflow', 'visible')
         .append('svg:path')
         .attr('d', 'M 0,-2.5 L 5 ,0 L 0, 2.5 L 0, -2.5')
         .attr('fill', '#000')
         .style('stroke','none')
         .style('stroke-width', '1')
+
+    //------------------------------
+    // Next_one_way_combined
+    //  This marker will get displayed 
+    //  in case two activities are 
+    //  both next_one_way
+    //------------------------------
 
     svg.append('defs')
         .append('marker')
@@ -268,7 +199,6 @@ export const generateMarkers = (svg, radius) => {
         .attr('orient', 'auto')
         .attr('markerWidth', 6)
         .attr('markerHeight', 6)
-        .attr('xoverflow', 'visible')
         .append('circle')
         .attr('r', 2)
         .attr('fill', '#f4f6f8')
@@ -282,12 +212,12 @@ export const generateMarkers = (svg, radius) => {
     let next_both_ways_start = svg.append('defs')
         .append('marker')
         .attr('id', 'next_both_ways_start')
-        .attr('viewBox', '-2.5 -2.5 5 10')
+        .attr('viewBox', '-2.5 -2.5 10 5')
         .attr('refX', -radius + 4.5)
         .attr('refY', 0)
         .attr('orient', 'auto')
-        .attr('markerWidth', 20)
-        .attr('markerHeight', 10)
+        .attr('markerWidth', 10)
+        .attr('markerHeight', 5)
         .attr('xoverflow', 'visible')
 
     next_both_ways_start
@@ -300,26 +230,27 @@ export const generateMarkers = (svg, radius) => {
     next_both_ways_start
         .append('svg:path')
                    // Trianlge on the bottom
-        .attr('d', 'M 2.5,0 L 7.5 ,-2.5 L 7.5, 2.5 L 2.5, 0')
+        .attr('d', 'M 2.5 0 L 7.5 -2.5 L 7.5 2.5 L 2.5 0')
                 //    'M 5 -2.5 L 10 -2.5 L 10 2.5 L 5 2.5' + // Outer rect
                 //    'L 5.5 2 L 9.5 2 L 9.5 -2 L 5.5 -2 L 5.5 2 L 5 2.5  M 0,-2.5') // Inner rect
         .attr('fill', '#000')
         
         .style('stroke','none')
         .style('stroke-width', 'none')
-        .attr('x', '10')
+        .attr('x', '7.5')
         .attr('y', '-2.25')
 
     let next_both_ways_end = svg.append('defs')
         .append('marker')
         .attr('id', 'next_both_ways_end')
-        .attr('viewBox', '-2.5 -2.5 5 10')
-        .attr('refX', radius + 3.5)
+        .attr('viewBox', '-2.5 -2.5 10 5')
+        .attr('refX', radius + 1)
         .attr('refY', 0)
         .attr('orient', 'auto')
-        .attr('markerWidth', 20)
-        .attr('markerHeight', 10)
+        .attr('markerWidth', 10)
+        .attr('markerHeight', 5)
         .attr('xoverflow', 'visible')
+        .attr('yoverflow', 'visible')
 
     next_both_ways_end
         .append('circle')
@@ -327,36 +258,16 @@ export const generateMarkers = (svg, radius) => {
         .attr('fill', '#f4f6f8')
         .style('stroke','black')
         .style('stroke-width', '0.5')
-        .attr('cx', '8')
+        .attr('xoverflow', 'visible')
+        .attr('cx', '5')
 
     next_both_ways_end
         .append('svg:path')
-                   // Trianlge on the bottom
-        .attr('d', 'M 0, -2.5 L 5 ,0 L 0, 2.5 L 0, -2.5')
-                //    'M 5 -2.5 L 10 -2.5 L 10 2.5 L 5 2.5' + // Outer rect
-                //    'L 5.5 2 L 9.5 2 L 9.5 -2 L 5.5 -2 L 5.5 2 L 5 2.5  M 0,-2.5') // Inner rect
+        // Trianlge on the bottom
+        .attr('d', 'M -2.5 -2.5 L 2.5 0 L -2.5 2.5 L -2.5 -2.5')
         .attr('fill', '#000')
-        
         .style('stroke','none')
         .style('stroke-width', 'none')
-        .attr('x', '10')
-        .attr('y', '-2.25')
-
-    // let next_both_ways_end = svg.append('defs')
-    //     .append('marker')
-    //     .attr('id', 'next_both_ways_end')
-    //     .attr('viewBox', '-0 -2.5 5 10')
-    //     .attr('refX', radius / 1.5 + 2.5)
-    //     .attr('refY', 0)
-    //     .attr('orient', 'auto')
-    //     .attr('markerWidth', 20)
-    //     .attr('markerHeight', 10)
-    //     .attr('xoverflow', 'visible')
-    //     .append('svg:path')
-    //     .attr('d', 'M 0,-2.5 L 5 ,0 L 0, 2.5 L 0, -2.5')
-    //     .attr('fill', '#000')
-    //     .style('stroke','none')
-    //     .style('stroke-width', '1')
 
 } 
 

--- a/log-skeleton/src/lib/common/graph-visualizer.js
+++ b/log-skeleton/src/lib/common/graph-visualizer.js
@@ -1,5 +1,4 @@
 import * as d3 from 'd3'
-import { text } from 'd3';
 import { generateMarkers } from './d3-markers';
 import { trimString } from './trim-strings';
 

--- a/log-skeleton/src/lib/common/graph-visualizer.js
+++ b/log-skeleton/src/lib/common/graph-visualizer.js
@@ -183,7 +183,7 @@ export const runForceGraph = (container) => {
             .attr("marker-end", d => d.markerEnd != null ? `url(#${d.markerEnd})` : null)
             .attr('transform', zoom)
         
-        link.append("title").text(d => d.type)
+        // link.append("title").text(d => d.type)
     
         // Add all the nodes
         node = svg
@@ -205,12 +205,8 @@ export const runForceGraph = (container) => {
         circles.remove()
             
         circles = node
-            // .append("g")
-
-        // circles
             .append("circle")
             .merge(circles)
-            // .style('opacity', '0.5')
             .attr("class", "node")
             .attr("r", radius)
             .style("fill", d => d.color)
@@ -223,9 +219,6 @@ export const runForceGraph = (container) => {
         labels.remove()
 
         labels = node
-        //     .append("g")
-
-        // labels
             .append("text")
             .text(d => trimString(d.name, 6, false))
             .attr("class", "label")
@@ -259,7 +252,7 @@ export const runForceGraph = (container) => {
 
         d.x = (event.sourceEvent.layerX - zoom.x) / zoom.k
         d.y = (event.sourceEvent.layerY - zoom.y) / zoom.k
-        
+
         if (currentTooltipNode != null &&
             currentTooltipNode.id != null &&
             d.id === currentTooltipNode.id) {

--- a/log-skeleton/src/lib/common/graph-visualizer.js
+++ b/log-skeleton/src/lib/common/graph-visualizer.js
@@ -1,4 +1,5 @@
 import * as d3 from 'd3'
+import { text } from 'd3';
 import { generateMarkers } from './d3-markers';
 import { trimString } from './trim-strings';
 
@@ -85,8 +86,12 @@ export const runForceGraph = (container) => {
             zoom = event.transform
             zoomLevel.style('opacity', 1)
             zoomLevel.html(`${(zoom.k * 100).toFixed(1)}%`)
+            // svg.attr('transform', event.transform)
             node.attr("transform", event.transform)
             link.attr("transform", event.transform)
+            // circles.selectAll('circles').attr("transform", event.transform)
+            // labels.selectAll('circles').attr("transform", event.transform)
+
         })
         .on("end", (event) => {
             setTimeout(() => {
@@ -143,7 +148,7 @@ export const runForceGraph = (container) => {
         .force("link", d3.forceLink()
             .id(function (d) { return d.id; }))
         .force("charge", d3.forceManyBody()
-            .strength(function (d) { return -1500; }))
+            .strength(function (d) { return -2000; }))
         .force("center", d3.forceCenter(width / 2, height / 2))
         .alphaDecay(0.02)
         .velocityDecay(0.8)
@@ -189,26 +194,27 @@ export const runForceGraph = (container) => {
             // .enter()
             .append("g")
             .on('click', clickNode)
+            .attr('transform', zoom)
+            .merge(node)
             .call(d3.drag()
                 .on("start", dragstarted)
                 .on("drag", dragged)
                 .on("end", dragended)
             )
-            .attr('transform', zoom)
-            .merge(node)
 
         circles.remove()
             
         circles = node
+            // .append("g")
+
+        // circles
             .append("circle")
             .merge(circles)
             // .style('opacity', '0.5')
             .attr("class", "node")
             .attr("r", radius)
             .style("fill", d => d.color)
-            // .attr('stroke-width', 5)
-            // .attr('stroke', 'transparent')
-            
+            .style("pointer-events", "none")
 
         node.append("title")
             .text(d => d.name)
@@ -217,14 +223,16 @@ export const runForceGraph = (container) => {
         labels.remove()
 
         labels = node
-            .append("g")
+        //     .append("g")
 
-        labels
+        // labels
             .append("text")
             .text(d => trimString(d.name, 6, false))
             .attr("class", "label")
             .attr("dy", d => d.isExtension ? 5 : 3)
             .attr("text-anchor", "middle")
+            .attr('width', 2 * radius)
+            .attr('height', 2 * radius)
             .style('font-size', d => d.isExtension ? '16px' : '10px')
         
         //	Set nodes, links, and alpha target for simulation
@@ -249,12 +257,9 @@ export const runForceGraph = (container) => {
 
     function dragged(event, d) {
 
-        // console.log(zoom);
-        // console.log(event);
-
         d.x = (event.sourceEvent.layerX - zoom.x) / zoom.k
         d.y = (event.sourceEvent.layerY - zoom.y) / zoom.k
-
+        
         if (currentTooltipNode != null &&
             currentTooltipNode.id != null &&
             d.id === currentTooltipNode.id) {
@@ -270,32 +275,22 @@ export const runForceGraph = (container) => {
         
     }
 
-    function clipX(x) {
-        return x
-        // return Math.max(radius * 1.5, Math.min(width - radius * 1.5, x))
-    }
-
-    function clipY(y) {
-        return y
-        // return Math.max(radius * 2.5, Math.min(height - radius * 2.5, y))
-    }
-
     //	tick event handler (nodes bound to container)
     function ticked() {
         link
-            .attr("x1", function (d) { return clipX(d.source.x) })
-            .attr("y1", function (d) { return clipY(d.source.y) })
-            .attr("x2", function (d) { return clipX(d.target.x) })
-            .attr("y2", function (d) { return clipY(d.target.y) })
+            .attr("x1", function (d) { return d.source.x })
+            .attr("y1", function (d) { return d.source.y })
+            .attr("x2", function (d) { return d.target.x })
+            .attr("y2", function (d) { return d.target.y })
 
         node.selectAll("circle")
-            .attr("cx", function(d) { return d.x = clipX(d.x) })
-            .attr("cy", function(d) { return d.y = clipY(d.y) })
+            .attr("cx", function(d) { return d.x })
+            .attr("cy", function(d) { return d.y })
 
-        labels
+        node
             .selectAll("text")
-            .attr("x", function(d) { return d.x = clipX(d.x) })
-            .attr("y", function(d) { return d.y = clipY(d.y) })
+            .attr("x", function(d) { return d.x })
+            .attr("y", function(d) { return d.y })
 
     }
 

--- a/log-skeleton/src/lib/common/model-converter.js
+++ b/log-skeleton/src/lib/common/model-converter.js
@@ -66,8 +66,6 @@ export const graphConverter = (logSkeleton, activities, start, end) => {
 
     const reducedLogSkeleton = relationshipsHierarchy(logSkeleton)
 
-    console.log(reducedLogSkeleton);
-
     let graph = {
         nodes: [],
         links: []
@@ -139,9 +137,6 @@ export const graphConverter = (logSkeleton, activities, start, end) => {
 
         edges = edges.concat(ed)
     }
-
-    console.log(edges);
-
 
     graph.links = reduceEdges(edges)
     graph.counter = logSkeleton['counter']

--- a/log-skeleton/src/styles/Content.module.css
+++ b/log-skeleton/src/styles/Content.module.css
@@ -2,6 +2,8 @@
     height: calc(100% - 60px);
     width: 100%;
     display: grid;
+    overflow: hidden;
+    margin: 0;
     grid-template-columns: min(15%, 300px) auto min(15%, 300px);
     grid-template-rows: 100%;
 }
@@ -36,6 +38,7 @@
     }
 }
 
+/* Very small screens */
 @media only screen and (max-width: 1000px) {
     .content {
         grid-template-columns: 25% auto 25%;

--- a/log-skeleton/src/styles/Content.module.css
+++ b/log-skeleton/src/styles/Content.module.css
@@ -2,7 +2,7 @@
     height: calc(100% - 60px);
     width: 100%;
     display: grid;
-    grid-template-columns: 15% auto 15%;
+    grid-template-columns: min(15%, 300px) auto min(15%, 300px);
     grid-template-rows: 100%;
 }
 
@@ -23,7 +23,7 @@
     width: 100%;
     height: 100%;
     min-width: 200px;
-    max-width: 300px;
+    /* max-width: 300px; */
     display: flex;
     flex-direction: column;
     justify-content: flex-start;

--- a/log-skeleton/src/styles/Graph.css
+++ b/log-skeleton/src/styles/Graph.css
@@ -17,6 +17,8 @@
     font-weight: 600;
     fill: white;
     cursor: pointer;
+    min-width: 40;
+    min-height: 40;
     /* filter: drop-shadow( 3px 0px 10px rgb(255, 255, 255)); */
     /* text-shadow: 0px 0px 10px rgb(156, 156, 156); */
 }
@@ -63,14 +65,11 @@ text {
 .tooltip {
     position: absolute;
     text-align: center;
-    /* overflow: scroll; */
     z-index: 10;
     min-width: 110px;
     padding: 10px;
     font: 12px sans-serif;
-    /* background: white; */
-    backdrop-filter: blur(40px);
-    /* border: 1px var(--border-color) solid; */
+    background-color: rgba(255, 255, 255, .9);
     border-radius: 8px;
     pointer-events: none;
     box-shadow: 0 0 25px 0 rgba(0, 0, 0, 0.1);
@@ -106,6 +105,19 @@ text {
   transition: opacity 300ms ease-in-out;
   padding: 10px;
   border-radius: 5px;
-  backdrop-filter: blur(100px);
+  background-color: rgba(255, 255, 255, .95);
   pointer-events: none;
+}
+
+
+@supports ((backdrop-filter: blur(40px))) {
+  .tooltip {
+    background-color: transparent;
+    backdrop-filter: blur(40px);
+  }
+
+  #zoomLevel {
+    background-color: transparent;
+    backdrop-filter: blur(100px);
+  }
 }

--- a/log-skeleton/src/styles/MainPanel.module.css
+++ b/log-skeleton/src/styles/MainPanel.module.css
@@ -2,7 +2,7 @@
     background-color: rgb(244, 246, 248);
     width: 100%;
     height: 100%;
-    overflow: scroll;
+    /* overflow: scroll; */
 }
 
 /* Empty Panel */

--- a/log-skeleton/src/styles/SidePanel.module.css
+++ b/log-skeleton/src/styles/SidePanel.module.css
@@ -86,3 +86,33 @@
     display: flex;
     flex-direction: row;
 }
+
+input {
+    -webkit-appearance: none;  /* Override default CSS styles */
+    appearance: none;
+    border-radius: 12.5px;
+    width: 100%;
+    height: 5px;
+    margin: 5px 0 ;
+    background: #d3d3d3; /* Grey background */
+    outline: none; /* Remove outline */
+    opacity: 0.7; /* Set transparency (for mouse-over effects on hover) */
+    -webkit-transition: .2s; /* 0.2 seconds transition on hover */
+    transition: opacity .2s;
+}
+
+.slider::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 15px;
+    height: 15px;
+    background: rgb(3, 102, 214);
+    cursor: pointer;
+    border-radius: 7.5px;
+}
+
+.slider::-webkit-slider-thumb:hover {
+    background: rgb(37, 107, 187);
+}
+
+


### PR DESCRIPTION
This PR includes a variety of fixes that the Fronend application had in the Firefox Browser.

The issues include:
1. Dragging nodes snapped to `(0, 0)` coordinate
2. Markers on the edges would not be displayed correctly
3. Backdrop blur is not applied

##### 1.  Dragging nodes snapped to `(0, 0)` coordinate
The problem was that the `event.sourceTarget.layerX/Y` variable did not worked as intended on Firefox when dragging a circle. When dragging on a `svg:text` the var has the relative position to the parent element, in this case the `svg` itself.
However, when dragging on the circle the variable contains the relative offset to itself.
Since both the `circle` and the `text` allow pointer interaction the drag interaction would sometimes be applied to the underlying `circle` which then caused the **bug**.
The problem was **fixed** by disabling `pointer-interaction` on the circle.

##### 2. Markers on the edges would not be displayed correctly
The problem was that the sizing of the markers was setup in a wrong way, which apparently Chrome & Safari were still able
to manage. However, the markers have been reworked and everything should be fine now.

##### 3. Backdrop blur is not applied
The problem was that, however, Firefox does not support `backdrop-filter: blur(...)`.
From now on the _blurry_ background defaults to a slightly transparent white background but in case `backdrop-filter: blur(...)` is supported the background color will get replaced by a blurred backdrop-filter.

Further the `Noise-Threshold` UI & UX has been reworked and improved.

Fixes issue #29 